### PR TITLE
Add input name on checkbox

### DIFF
--- a/site/src/from/net-neutrality.html
+++ b/site/src/from/net-neutrality.html
@@ -13,7 +13,7 @@ jumbotron: 'Stand up for Net Neutrality'
   </h3>
 
   <div class="form-section">
-    <form class="bsd-form" role="form" method="post" action="https://sendto.mozilla.org/page/s/webmaker-training">
+    <form class="bsd-form" role="form" method="post" action="https://sendto.webmaker.org/page/s/webmaker-training">
       <div class="form-group">
         <div class="email input-group">
           <span class="input-group-addon"><span class="fa fa-envelope"></span></span>
@@ -23,7 +23,7 @@ jumbotron: 'Stand up for Net Neutrality'
           <button type="submit" class="btn btn-primary">Register</button>
         </p>
         <div class="accept input-group">
-          <input id="allow_email" class="pull-left input-left" type="checkbox" required>
+          <input id="allow_email" name="custom-2547" class="pull-left input-left" type="checkbox" required>
           <label for="allow_email" class="help-block"><strong>Yes!</strong> I
             want to receive email updates about Mozilla’s projects and campaigns
             and I’m okay with you handling this info as you explain in your


### PR DESCRIPTION
Adding `name="custom-2547"` makes the form work for me, but feels brittle. 

I've also switched the BSD domain to webmaker so we can set a conversion event on the thank you page.
