### PR TITLE
Bug 1046257: Fix .webmaker-landing h3 margin for small viewports

### DIFF
--- a/site/less/pages/webmaker.less
+++ b/site/less/pages/webmaker.less
@@ -75,7 +75,6 @@
       line-height: 1.2;
       padding: 0.2rem 0;
       width: 27.5rem;
-      margin: 0 auto;
       text-align: left;
     }
 


### PR DESCRIPTION
This affects both the /from/net-neutrality landing page as well as the /signup landing page (which had the same issue).
